### PR TITLE
✨ feat : 랜딩페이지, 헤더 구현

### DIFF
--- a/apps/web/app/(public)/home/Header/Header.tsx
+++ b/apps/web/app/(public)/home/Header/Header.tsx
@@ -16,7 +16,7 @@ export default function Header() {
   }, [open]);
 
   // 오버레이 클릭으로 닫기 (사이드바 외부 클릭)
-  const onOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!drawerRef.current) return;
     if (!drawerRef.current.contains(e.target as Node)) {
       setOpen(false);
@@ -62,7 +62,7 @@ export default function Header() {
           aria-label="Open menu"
           aria-expanded={open}
           onClick={() => setOpen(true)}
-          className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-white/10 text-white/90 hover:bg-white/5 active:scale-95"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md text-white/90 hover:bg-white/5 active:scale-95"
         >
           {/* 햄버거 아이콘 (inline svg) */}
           <svg
@@ -87,7 +87,7 @@ export default function Header() {
         className={`fixed inset-0 z-40 bg-black/40 backdrop-blur-sm transition-opacity duration-300 ${
           open ? "opacity-100" : "pointer-events-none opacity-0"
         }`}
-        onClick={onOverlayClick}
+        onClick={handleOverlayClick}
       />
 
       {/* 오른쪽 사이드바 드로어 */}
@@ -107,7 +107,7 @@ export default function Header() {
           <button
             aria-label="Close menu"
             onClick={() => setOpen(false)}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-white/10 text-white/80 hover:bg-white/5 active:scale-95"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md text-white/80 hover:bg-white/5 active:scale-95"
           >
             {/* 닫기 아이콘 */}
             <svg

--- a/apps/web/app/(public)/home/Header/index.ts
+++ b/apps/web/app/(public)/home/Header/index.ts
@@ -1,0 +1,1 @@
+export { default as Header } from "./Header";

--- a/apps/web/app/(public)/home/Header/index.tsx
+++ b/apps/web/app/(public)/home/Header/index.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@triad/ui";
+
+export default function Header() {
+  return (
+    <header className="sticky left-0 right-0 top-0 z-50 flex h-[64px] items-center justify-between bg-zinc-950 px-16">
+      <div className="text-lg font-bold tracking-widest text-white">TRIAD</div>
+
+      <nav>
+        <ul>
+          <li className="flex items-center gap-4">
+            <Button variant="link" className="text-gray-200">
+              Home
+            </Button>
+
+            <Button variant="link" className="text-gray-200">
+              About
+            </Button>
+
+            <Button variant="link" className="text-gray-200">
+              Contact
+            </Button>
+          </li>
+        </ul>
+      </nav>
+
+      <Button variant="secondary" size="sm" className="text-xs font-semibold">
+        Contact Us
+      </Button>
+    </header>
+  );
+}

--- a/apps/web/app/(public)/home/Header/index.tsx
+++ b/apps/web/app/(public)/home/Header/index.tsx
@@ -1,21 +1,47 @@
+"use client";
+
 import { Button } from "@triad/ui";
+import { useEffect, useRef, useState } from "react";
 
 export default function Header() {
+  const [open, setOpen] = useState(false);
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+
+  // 열렸을 때 배경 스크롤 잠금
+  useEffect(() => {
+    const root = document.documentElement;
+    if (open) root.classList.add("overflow-hidden");
+    else root.classList.remove("overflow-hidden");
+    return () => root.classList.remove("overflow-hidden");
+  }, [open]);
+
+  // 오버레이 클릭으로 닫기 (사이드바 외부 클릭)
+  const onOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!drawerRef.current) return;
+    if (!drawerRef.current.contains(e.target as Node)) {
+      setOpen(false);
+    }
+  };
+
   return (
-    <header className="sticky left-0 right-0 top-0 z-50 flex h-[64px] items-center justify-between bg-zinc-950 px-16">
+    <header className="fixed left-0 right-0 top-0 z-50 flex h-[64px] items-center justify-between bg-zinc-950 px-4 sm:px-8 md:px-16">
+      {/* 로고 */}
       <div className="text-lg font-bold tracking-widest text-white">TRIAD</div>
 
-      <nav>
-        <ul>
-          <li className="flex items-center gap-4">
+      {/* 데스크톱 내비게이션 */}
+      <nav className="hidden md:block">
+        <ul className="flex items-center gap-4">
+          <li>
             <Button variant="link" className="text-gray-200">
               Home
             </Button>
-
+          </li>
+          <li>
             <Button variant="link" className="text-gray-200">
               About
             </Button>
-
+          </li>
+          <li>
             <Button variant="link" className="text-gray-200">
               Contact
             </Button>
@@ -23,9 +49,128 @@ export default function Header() {
         </ul>
       </nav>
 
-      <Button variant="secondary" size="sm" className="text-xs font-semibold">
-        Contact Us
-      </Button>
+      {/* 데스크톱 CTA */}
+      <div className="hidden md:block">
+        <Button variant="secondary" size="sm" className="text-xs font-semibold">
+          Contact Us
+        </Button>
+      </div>
+
+      {/* 모바일 햄버거 버튼 */}
+      <div className="md:hidden">
+        <button
+          aria-label="Open menu"
+          aria-expanded={open}
+          onClick={() => setOpen(true)}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-white/10 text-white/90 hover:bg-white/5 active:scale-95"
+        >
+          {/* 햄버거 아이콘 (inline svg) */}
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 6h18M3 12h18M3 18h18"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* 오버레이 */}
+      <div
+        className={`fixed inset-0 z-40 bg-black/40 backdrop-blur-sm transition-opacity duration-300 ${
+          open ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        onClick={onOverlayClick}
+      />
+
+      {/* 오른쪽 사이드바 드로어 */}
+      <div
+        ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
+        className={`fixed right-0 top-0 z-50 flex h-full w-[78%] max-w-[320px] flex-col bg-zinc-900/95 shadow-2xl ring-1 ring-white/10 backdrop-blur-md transition-transform duration-300 ease-[cubic-bezier(.22,.61,.36,1)] ${
+          open ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        {/* 드로어 헤더 */}
+        <div className="flex h-[64px] items-center justify-between px-4">
+          <span className="text-sm font-semibold tracking-widest text-white/90">
+            MENU
+          </span>
+          <button
+            aria-label="Close menu"
+            onClick={() => setOpen(false)}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-white/10 text-white/80 hover:bg-white/5 active:scale-95"
+          >
+            {/* 닫기 아이콘 */}
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M6 6l12 12M18 6L6 18"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* 드로어 내비 리스트 */}
+        <nav className="px-2">
+          <ul className="flex flex-col gap-1">
+            <li>
+              <Button
+                variant="ghost"
+                className="w-full justify-start rounded-xl px-3 py-3 text-base text-white/90 hover:bg-white/5"
+                onClick={() => setOpen(false)}
+              >
+                Home
+              </Button>
+            </li>
+            <li>
+              <Button
+                variant="ghost"
+                className="w-full justify-start rounded-xl px-3 py-3 text-base text-white/90 hover:bg-white/5"
+                onClick={() => setOpen(false)}
+              >
+                About
+              </Button>
+            </li>
+            <li>
+              <Button
+                variant="ghost"
+                className="w-full justify-start rounded-xl px-3 py-3 text-base text-white/90 hover:bg-white/5"
+                onClick={() => setOpen(false)}
+              >
+                Contact
+              </Button>
+            </li>
+          </ul>
+        </nav>
+
+        {/* 드로어 푸터 CTA */}
+        <div className="mt-auto border-t border-white/10 p-4">
+          <Button
+            variant="secondary"
+            className="w-full justify-center text-sm font-semibold"
+            onClick={() => setOpen(false)}
+          >
+            Contact Us
+          </Button>
+        </div>
+      </div>
     </header>
   );
 }

--- a/apps/web/app/(public)/home/page.tsx
+++ b/apps/web/app/(public)/home/page.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from "motion/react";
 
-import Header from "./Header";
+import { Header } from "./Header";
 
 const DURATION = 1.2;
 

--- a/apps/web/app/(public)/home/page.tsx
+++ b/apps/web/app/(public)/home/page.tsx
@@ -1,0 +1,13 @@
+import Header from "./Header";
+
+export default function Home() {
+  return (
+    <main className="w-full bg-zinc-950">
+      <Header />
+
+      <div className="text-white">
+        <div className="h-[1000px]">Section 1</div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/(public)/home/page.tsx
+++ b/apps/web/app/(public)/home/page.tsx
@@ -1,13 +1,155 @@
+"use client";
+
+import { motion } from "motion/react";
+
 import Header from "./Header";
+
+const DURATION = 1.2;
+
+const LINES = [
+  "The single workspace where",
+  "developers ship,",
+  "planners steer, and",
+  "designers shine,",
+  "as one.",
+];
 
 export default function Home() {
   return (
-    <main className="w-full bg-zinc-950">
+    <main className="relative h-screen w-full overflow-hidden bg-zinc-950 px-6 pt-[64px] sm:px-12 md:px-16">
       <Header />
 
-      <div className="text-white">
-        <div className="h-[1000px]">Section 1</div>
-      </div>
+      {/* 카피 영역 */}
+      <section className="mt-20 select-none text-white md:mt-40">
+        {/* 상단 서브헤드 살짝 페이드 */}
+        <motion.p
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 0.7, y: 0 }}
+          transition={{ duration: 0.5, ease: "easeIn", delay: 0.15 }}
+          className="text-sm tracking-wide text-zinc-300"
+        >
+          Built for product teams
+        </motion.p>
+
+        {/* 메인 헤드라인: 라인 스태거 + 블러 아웃 + 살짝 스케일 */}
+        <div className="mt-4 font-semibold">
+          {LINES.map((text, i) => (
+            <motion.p
+              key={text}
+              initial={{
+                opacity: 0,
+                y: 18,
+                filter: "blur(6px)",
+                scale: 0.985,
+                clipPath: "inset(0 100% 0 0)",
+              }}
+              animate={{
+                opacity: 1,
+                y: 0,
+                filter: "blur(0px)",
+                scale: 1,
+                clipPath: "inset(0 0% 0 0)",
+              }}
+              transition={{
+                duration: DURATION,
+                ease: "easeIn",
+                delay: 0.18 * i,
+              }}
+              className={`w-fit pb-[5px] text-4xl sm:text-5xl md:text-6xl ${
+                i === LINES.length - 1 ? "text-white" : "text-white/95"
+              }`}
+            >
+              {/* 단어별 살짝 딜레이(더 섬세한 리듬) */}
+              <span className="inline-block [transform-origin:0_50%]">
+                {text.split(" ").map((word, j) => (
+                  <motion.span
+                    key={`${word}-${j}`}
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{
+                      duration: 0.5,
+                      ease: "easeIn",
+                      delay: 0.18 * i + j * 0.04,
+                    }}
+                    className="mr-2 inline-block"
+                  >
+                    {word}
+                  </motion.span>
+                ))}
+              </span>
+            </motion.p>
+          ))}
+        </div>
+
+        {/* 하이라이트 라인 언더라인 와이프 */}
+        <motion.div
+          initial={{ scaleX: 0, opacity: 0.7 }}
+          animate={{ scaleX: 1, opacity: 1 }}
+          transition={{
+            duration: 0.7,
+            ease: "easeIn",
+            delay: 0.18 * (LINES.length - 1) + 0.4,
+          }}
+          className="mt-3 h-[3px] w-48 origin-left rounded-full bg-gradient-to-r from-indigo-400 via-sky-300 to-fuchsia-300"
+        />
+
+        {/* 설명 텍스트: 아래에서 위로 살짝 */}
+        <motion.p
+          initial={{ opacity: 0, y: 14 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{
+            duration: 0.6,
+            ease: "easeIn",
+            delay: 0.18 * (LINES.length - 1) + 0.6,
+          }}
+          className="mt-6 max-w-xl text-zinc-400"
+        >
+          Work together, Collaborate faster
+        </motion.p>
+
+        {/* CTA: 마이크로 인터랙션 */}
+        <div className="mt-8 flex gap-3">
+          <motion.button
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            whileHover={{ y: -1, scale: 1.01 }}
+            whileTap={{ scale: 0.99 }}
+            transition={{
+              duration: 0.4,
+              ease: "easeIn",
+              delay: 0.18 * (LINES.length - 1) + 0.75,
+            }}
+            className="rounded-2xl bg-white px-5 py-3 text-sm font-medium text-zinc-900 shadow-[0_6px_20px_rgba(255,255,255,0.06)]"
+          >
+            Get started
+          </motion.button>
+
+          <motion.button
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            whileHover={{ y: -1 }}
+            whileTap={{ scale: 0.99 }}
+            transition={{
+              duration: 0.4,
+              ease: "easeIn",
+              delay: 0.18 * (LINES.length - 1) + 0.85,
+            }}
+            className="rounded-2xl border border-white/15 bg-white/5 px-5 py-3 text-sm font-normal text-white/90 backdrop-blur-md"
+          >
+            Watch demo
+          </motion.button>
+        </div>
+      </section>
+
+      {/* 그라디언트 텍스트 애니메이션 키프레임 (Tailwind 커스텀 없이 인라인) */}
+      <style>{`
+        @keyframes gradientShift { to { background-position: 200% 0; } }
+        .gradient-text { 
+          background: linear-gradient(90deg, #fafafa, #a5b4fc, #f0abfc, #fafafa);
+          -webkit-background-clip: text; background-clip: text; color: transparent;
+          background-size: 200% 100%; animation: gradientShift 10s linear infinite;
+        }
+      `}</style>
     </main>
   );
 }

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -1,13 +1,6 @@
-import { Button } from "@triad/ui";
+// app/page.tsx
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  return (
-    <div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 pb-20 sm:p-20">
-      <main className="row-start-2 flex flex-col items-center gap-8 sm:items-start">
-        <h1 className="text-4xl font-bold">Welcome to Triad</h1>
-        <p className="text-lg">Your Next.js 15 app is running!</p>
-        <Button variant="destructive">asd</Button>
-      </main>
-    </div>
-  );
+  redirect("/home");
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,13 +10,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "15.0.3",
-    "@triad/ui": "workspace:*"
+    "@triad/ui": "workspace:*",
+    "motion": "^12.23.22",
+    "next": "15.0.3"
   },
   "devDependencies": {
     "@triad/eslint-config": "workspace:*",
-    "@triad/typescript-config": "workspace:*",
     "@triad/tailwindcss-config": "workspace:*",
+    "@triad/typescript-config": "workspace:*",
     "eslint-config-next": "15.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,6 @@ importers:
       '@triad/ui':
         specifier: workspace:*
         version: link:../../packages/ui
-      react-use-websocket:
-        specifier: ^4.9.0
-        version: 4.13.0
     devDependencies:
       '@triad/eslint-config':
         specifier: workspace:*
@@ -88,6 +85,9 @@ importers:
       '@triad/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      motion:
+        specifier: ^12.23.22
+        version: 12.23.22(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       next:
         specifier: 15.0.3
         version: 15.0.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -1970,6 +1970,20 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  framer-motion@12.23.22:
+    resolution: {integrity: sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fs-extra@11.3.1:
     resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
     engines: {node: '>=14.14'}
@@ -2620,6 +2634,26 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
+  motion-dom@12.23.21:
+    resolution: {integrity: sha512-5xDXx/AbhrfgsQmSE7YESMn4Dpo6x5/DTZ4Iyy4xqDvVHWvFVoV+V2Ri2S/ksx+D40wrZ7gPYiMWshkdoqNgNQ==}
+
+  motion-utils@12.23.6:
+    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
+
+  motion@12.23.22:
+    resolution: {integrity: sha512-iSq6X9vLHbeYwmHvhK//+U74ROaPnZmBuy60XZzqNl0QtZkWfoZyMDHYnpKuWFv0sNMqHgED8aCXk94LCoQPGg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -3069,9 +3103,6 @@ packages:
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
-
-  react-use-websocket@4.13.0:
-    resolution: {integrity: sha512-anMuVoV//g2N76Wxqvqjjo1X48r9Np3y1/gMl7arX84tAPXdy5R7sB5lO5hvCzQRYjqXwV8XMAiEBOUbyrZFrw==}
 
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
@@ -5651,6 +5682,15 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  framer-motion@12.23.22(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      motion-dom: 12.23.21
+      motion-utils: 12.23.6
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+
   fs-extra@11.3.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -6281,6 +6321,20 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
+  motion-dom@12.23.21:
+    dependencies:
+      motion-utils: 12.23.6
+
+  motion-utils@12.23.6: {}
+
+  motion@12.23.22(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      framer-motion: 12.23.22(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+
   ms@2.1.3: {}
 
   multimatch@6.0.0:
@@ -6718,8 +6772,6 @@ snapshots:
   react-is@16.13.1: {}
 
   react-refresh@0.17.0: {}
-
-  react-use-websocket@4.13.0: {}
 
   react@19.1.1: {}
 


### PR DESCRIPTION
## 🛠️ 작업 내용 (Content)
- `framer-motion`을 사용한 랜딩페이지 구현
- 헤더 구현

## 📝 상세 설명
- `motion` 의존성 설치

- 랜딩 페이지, 헤더 구현 > 모바일 반응형

- 원랜 한땀한땀 만들다가, 애니메이션은 Codex가 훨씬 더 잘 넣어주더군요. 후후.

- `svg`도 일단 `lucide icons` 사용 안 하고 그려서 넣었습니다.
  - 이건 `shadcn` 걷어내면 `lucide` 아이콘 사용 안 할 것 같아서 따로 수정 안 했어요
  - 의견 부탁드립니다

- 랜딩페이지에서 쓰는 텍스트 애니메이션은 재사용 고려하지 않는 게 나을 것 같아서, `<style>` + `keyframes`로 처리했습니다.

## ⚙️ 기타 사항
- 이거 랜딩페이지 렌더링 전략을 좀 수정해야할 것 같은데, 이건 추후 PR에서 처리할게용
